### PR TITLE
We should default to {{ openshift_project }}

### DIFF
--- a/grafana/s2i/grafana-buildconfig-template.yaml
+++ b/grafana/s2i/grafana-buildconfig-template.yaml
@@ -37,7 +37,7 @@ parameters:
   value: grafana-5.3.0-1.x86_64.rpm
   description: The grafana rpm
 - name: NAMESPACE
-  value: contra-sample-project
+  value: "{{ openshift_project }}"
 - name: GF_AUTH_ANONYMOUS_ENABLED
   value: "true"
 - name: INIT_DATASOURCE

--- a/influxdb/s2i/influxdb-buildconfig-template.yaml
+++ b/influxdb/s2i/influxdb-buildconfig-template.yaml
@@ -39,7 +39,7 @@ parameters:
   value: db0
   description: The initial db that will be created
 - name: NAMESPACE
-  value: contra-sample-project
+  value: "{{ openshift_project }}"
   description: The imageStream namespace
 objects:
 - apiVersion: v1

--- a/jenkins/master/s2i/jenkins-persistent-template.yml
+++ b/jenkins/master/s2i/jenkins-persistent-template.yml
@@ -284,7 +284,7 @@ parameters:
 - name: NAMESPACE
   displayName: Jenkins ImageStream Namespace
   description: The OpenShift Namespace where the Jenkins ImageStream resides.
-  value: contra-sample-project
+  value: "{{ openshift_project }}"
 - name: JENKINS_IMAGE_STREAM_TAG
   displayName: Jenkins ImageStreamTag
   description: Name of the ImageStreamTag to be used for the Jenkins image.


### PR DESCRIPTION
- contra-env-setup defines the OpenShift project
- The template deployment config can be overwritten using template directly
- The following templates in the infra have deployment configs