### PR TITLE
Setting ansible version to 2.7.1 as per Linchpin requirements

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:28
 
 LABEL name="contrainfra/ansible-executor" \
       maintainer="rnester@redhat.com, cmays@redhat.com, ari@redhat.com" \
-      version="0.0.5" \
+      version="2.7.1" \
       description="A container to run test scripts, set resource configuration, etc."
 
 ENV APP_ROOT=/ansible/


### PR DESCRIPTION
https://github.com/CentOS-PaaS-SIG/linchpin/blob/develop/requirements.txt#L7