### PR TITLE
Bump openshift-login plugin to 1.0.16

### DIFF
--- a/jenkins/master/openshift/plugins.txt
+++ b/jenkins/master/openshift/plugins.txt
@@ -83,7 +83,7 @@ monitoring:1.73.1
 multiple-scms:0.6
 node-iterator-api:1.5
 openshift-client:1.0.23
-openshift-login:1.0.9
+openshift-login:1.0.16
 openshift-pipeline:1.0.55
 openshift-sync:1.0.27
 parameterized-trigger:2.35.2


### PR DESCRIPTION
Had to bump it to `1.0.16`, because with a fresh install of the env, I wasn't able to authenticate with OpenShift. There were no errors in Jenkins log, it added the user to matrix, but I wasn't authenticated at all. After upgrade I'm able to login.