### PR TITLE
Update ansible.cfg and add google auth libraries

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -21,7 +21,9 @@ RUN dnf install -y ansible \
         python3-boto3 \
         python2-libcloud \
         python3-libcloud \
-	    python2-virtualenv \
+	python2-google-auth \
+	python3-google-auth \
+    	python2-virtualenv \
         dumb-init \
         rsync && \
     dnf clean all && \

--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -23,6 +23,7 @@ RUN dnf install -y ansible \
         python3-libcloud \
 	python2-google-auth \
 	python3-google-auth \
+	python3-crypto \
     	python2-virtualenv \
         dumb-init \
         rsync && \

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,3 +3,4 @@ inventory = /ansible/inventory
 host_key_checking = False
 host_key_auto_add = True
 deprecation_warnings = False
+remote_tmp = /tmp/.ansible/tmp


### PR DESCRIPTION
Ansible was failing when using a building container because the folder was not writable, and GCP tests failed because of missing libraries

This PR adds the ansible.cfg line and the required packages for it to work again